### PR TITLE
suppress warning messages about compressed size being bigger than uncompressed size

### DIFF
--- a/dunedataprep/DataPrep/Tool/AcdDigitReader_tool.cc
+++ b/dunedataprep/DataPrep/Tool/AcdDigitReader_tool.cc
@@ -65,7 +65,7 @@ DataMap AcdDigitReader::update(AdcChannelData& acd) const {
   } else {
     unsigned int nsig = dig.Samples();
     acd.raw.resize(nsig, -999);  // See https://cdcvs.fnal.gov/redmine/issues/11572.
-    if ( nsig < dig.ADCs().size() ) {
+    if ( nsig < dig.ADCs().size() && m_LogLevel >= 4) {
       cout << myname << "WARNING: " << "Uncompressed size is smaller than compressed: "
            << nsig << " < " << dig.ADCs().size() << endl;
     }


### PR DESCRIPTION
David Adams didn't use MF but rather used cout and his own graded level of printout verbosity steered by m_LogLevel.  Mike Wang complained about a message that is mostly inconsequential (you set the zs threshold to zero and every channel wil warn like this).  So throttle it like the others.